### PR TITLE
Add Thalia support to pytolino

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,8 @@ if chromium browser is installed and there is a monitor, it can be done automati
 .. code-block:: python
 
     from pytolino.tolino_cloud import Client
-    partner = 'orellfuessli'
-    client = Client(partner=partner,username='USERNAME)
+    partner = 'orellfuessli'  # or 'thalia' / 'thalia_at'
+    client = Client(username='USERNAME', server_name=partner)
     client.login('PASSWORD')
 
 if this is the first login on the device, it will use selenium and store an access token on the device.
@@ -76,7 +76,9 @@ To get a list of the supported partners:
    from pytolino.tolino_cloud import PARTNERS
    print(PARTNERS)
 
-for now, only orelfuessli is supported, but it should be easy to include the others (but always need of a manual login)
+Supported partners currently include ``orellfuessli``, ``thalia`` and ``thalia_at``.
+Thalia uses the same Tolino backend endpoints as Orell Füssli, but the login flow
+is partner-specific.
 
 
 Features

--- a/src/pytolino/servers_settings.toml
+++ b/src/pytolino/servers_settings.toml
@@ -19,3 +19,43 @@ cookie_deny_all_css = '.sc-gsFSXq.xZpYl'
 username_field_id = 'email-input'
 password_field_id = 'password-input'
 submit_button_css = '.element-button-primary.button-submit'
+
+[thalia]
+partner_id = "2"
+client_id = "webshop01"
+scope = "SCOPE_BOSH"
+auth_url = "https://www.thalia.de/de.thalia.ecp.authservice.application/oauth2/authorize"
+token_url = "https://www.thalia.de/auth/oauth2/token"
+login_url = "https://www.thalia.de/de.thalia.ecp.authservice.application/login.do"
+upload_url = "https://bosh.pageplace.de/bosh/rest/upload"
+meta_url = "https://bosh.pageplace.de/bosh/rest/meta"
+cover_url = "https://bosh.pageplace.de/bosh/rest/cover"
+sync_data_url = "https://bosh.pageplace.de/bosh/rest/sync-data?paths=publications,audiobooks"
+delete_url = "https://bosh.pageplace.de/bosh/rest/deletecontent"
+download_info_url = "https://bosh.pageplace.de/bosh/rest/cloud/downloadinfo/{}/{}/type/external-download"
+inventory_url = "https://bosh.pageplace.de/bosh/rest/inventory/delta"
+shadow_host_id = "usercentrics-root"
+cookie_deny_all_css = '.sc-gsFSXq.xZpYl'
+username_field_id = 'j_username'
+password_field_id = 'j_password'
+submit_button_css = "button[type='submit'], input[type='submit'], .element-button-primary.button-submit"
+
+[thalia_at]
+partner_id = "4"
+client_id = "webshop01"
+scope = "SCOPE_BOSH SCOPE_BUCHDE"
+auth_url = "https://www.thalia.at/de.thalia.ecp.authservice.application/oauth2/authorize"
+token_url = "https://www.thalia.at/de.buch.appservices/api/4004/oauth2/token"
+login_url = "https://www.thalia.at/de.thalia.ecp.authservice.application/login.do"
+upload_url = "https://bosh.pageplace.de/bosh/rest/upload"
+meta_url = "https://bosh.pageplace.de/bosh/rest/meta"
+cover_url = "https://bosh.pageplace.de/bosh/rest/cover"
+sync_data_url = "https://bosh.pageplace.de/bosh/rest/sync-data?paths=publications,audiobooks"
+delete_url = "https://bosh.pageplace.de/bosh/rest/deletecontent"
+download_info_url = "https://bosh.pageplace.de/bosh/rest/cloud/downloadinfo/{}/{}/type/external-download"
+inventory_url = "https://bosh.pageplace.de/bosh/rest/inventory/delta"
+shadow_host_id = "usercentrics-root"
+cookie_deny_all_css = '.sc-gsFSXq.xZpYl'
+username_field_id = 'j_username'
+password_field_id = 'j_password'
+submit_button_css = "button[type='submit'], input[type='submit'], .element-button-primary.button-submit"

--- a/src/pytolino/tolino_cloud.py
+++ b/src/pytolino/tolino_cloud.py
@@ -15,9 +15,10 @@ import requests
 import curl_cffi
 from varboxes import VarBox
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from seleniumbase import SB
 
 
@@ -92,6 +93,17 @@ class Client(object):
 
         if not rsp.ok:
             raise PytolinoException("host response not ok")
+
+    def _find_first_element(self, driver, locators: list[tuple[By, str]]):
+        last_error = None
+        for by, value in locators:
+            try:
+                return driver.find_element(by, value)
+            except NoSuchElementException as exc:
+                last_error = exc
+        if last_error is not None:
+            raise last_error
+        raise NoSuchElementException("no locator candidates provided")
 
     def _store_current_token(self):
         """store the token with attribute of self"""
@@ -186,14 +198,8 @@ class Client(object):
         self._username_field_id = self._server_settings[
             server_settings_keys.USERNAME_FIELD_ID
         ]
-        self._username_field_id = self._server_settings[
-            server_settings_keys.USERNAME_FIELD_ID
-        ]
         self._cookie_deny_css = self._server_settings[
             server_settings_keys.COOKIE_DENY_CSS
-        ]
-        self._username_field_id = self._server_settings[
-            server_settings_keys.USERNAME_FIELD_ID
         ]
         self._password_field_id = self._server_settings[
             server_settings_keys.PASSWORD_FIELD_ID
@@ -300,40 +306,56 @@ class Client(object):
 
                 # deny cookies
                 shadow_host_id = self._shadow_host_id
-                shadow_host = driver.find_element(By.ID, shadow_host_id)
-                shadow_root = shadow_host.shadow_root
-                css = self._cookie_deny_css
-                wait = WebDriverWait(shadow_root, timeout)
-                deny_button = wait.until(
-                    expected_conditions.element_to_be_clickable(
-                        (By.CSS_SELECTOR, css)
+                try:
+                    shadow_host = driver.find_element(By.ID, shadow_host_id)
+                except NoSuchElementException:
+                    shadow_host = None
+                if shadow_host is not None:
+                    shadow_root = shadow_host.shadow_root
+                    css = self._cookie_deny_css
+                    wait = WebDriverWait(shadow_root, timeout)
+                    deny_button = wait.until(
+                        expected_conditions.element_to_be_clickable(
+                            (By.CSS_SELECTOR, css)
+                        )
                     )
-                )
-                deny_button.click()
+                    deny_button.click()
 
                 # fill credentials and submit
                 username_field_id = self._username_field_id
-                username_field = driver.find_element(
-                    By.ID,
-                    username_field_id,
+                username_field = self._find_first_element(
+                    driver,
+                    [
+                        (By.ID, username_field_id),
+                        (By.NAME, username_field_id),
+                    ],
                 )
                 password_field_id = self._password_field_id
-                password_field = driver.find_element(
-                    By.ID,
-                    password_field_id,
+                password_field = self._find_first_element(
+                    driver,
+                    [
+                        (By.ID, password_field_id),
+                        (By.NAME, password_field_id),
+                    ],
                 )
                 css = self._submit_css
-                submit_button = driver.find_element(
-                    By.CSS_SELECTOR,
-                    css,
-                )
                 username_field.send_keys(self._username)
                 password_field.send_keys(password)
-                wait = WebDriverWait(driver, timeout=timeout)
-                wait.until(
-                    expected_conditions.element_to_be_clickable(submit_button)
-                )
-                submit_button.click()
+                try:
+                    submit_button = driver.find_element(
+                        By.CSS_SELECTOR,
+                        css,
+                    )
+                except NoSuchElementException:
+                    password_field.send_keys(Keys.RETURN)
+                else:
+                    wait = WebDriverWait(driver, timeout=timeout)
+                    wait.until(
+                        expected_conditions.element_to_be_clickable(
+                            submit_button
+                        )
+                    )
+                    submit_button.click()
 
                 # get cookies
                 cookies = driver.get_cookies()

--- a/tests/test_tolino_cloud.py
+++ b/tests/test_tolino_cloud.py
@@ -15,7 +15,7 @@ import datetime
 from varboxes import VarBox
 
 
-from pytolino.tolino_cloud import Client, PytolinoException
+from pytolino.tolino_cloud import Client, PytolinoException, PARTNERS
 
 
 TEST_EPUB = "basic-v3plus2.epub"
@@ -37,6 +37,12 @@ class TestClient(unittest.TestCase):
                 server_name="this tolino partner does not exists",
                 username="username",
             )
+
+    def test_thalia_partners_supported(self):
+        self.assertIn("thalia", PARTNERS)
+        self.assertIn("thalia_at", PARTNERS)
+        Client(username="username", server_name="thalia")
+        Client(username="username", server_name="thalia_at")
 
 
 def upload_test():


### PR DESCRIPTION
## Summary

Add first-class Thalia support to `pytolino` so the Tolino Webreader flow can be used beyond `orellfuessli`.

This keeps the API layer reusable, but adds the partner-specific auth/settings needed by Thalia (`thalia` and `thalia_at`). I also hardened the login flow a bit so field lookup works with either `id` or `name`, and submission falls back to pressing Enter if the submit button is not exposed as a stable CSS selector.

## What changed

- Added `thalia` and `thalia_at` partner profiles in `servers_settings.toml`
- Kept the shared Tolino backend endpoints on the existing `bosh.pageplace.de` API
- Hardened Selenium login handling with:
  - `id` / `name` fallback for username and password fields
  - Enter-key fallback when the submit button is not stable
  - a small robustness fix for the cookie banner check
- Updated README usage docs and supported-partner notes
- Added a regression test that asserts the new partners are available

## Validation

- `python3 -m compileall -q src`
- `PYTHONPATH=/home/alois/Dokumente/development/github/pytolino/src:/tmp/pytolino-target python3 -m pytest tests -q`
- Live smoke test in the real Thalia Webreader:
  - login succeeded
  - upload succeeded
 
## Notes

- The shared Tolino cloud endpoints were already suitable for Thalia; the missing piece was partner configuration and login handling.
- `thalia_at` is included because the older Tolino client family has separate Thalia profiles and the same backend pattern.
